### PR TITLE
OpenAI連携API実装

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -9,6 +9,7 @@ services:
         mc alias set local http://minio:9000 minioadmin minioadmin &&
         mc mb -p local/generated || true &&
         mc mb -p local/uploads || true &&
+        mc anonymous set download local/uploads &&
         mc ls local
       "
     restart: "no"

--- a/front/nuxt.config.ts
+++ b/front/nuxt.config.ts
@@ -12,6 +12,7 @@ export default defineNuxtConfig({
     s3BucketName: process.env.S3_BUCKET_NAME,
     awsAccessKeyId: process.env.AWS_ACCESS_KEY_ID,
     awsSecretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    openaiApiKey: process.env.OPENAI_API_KEY,
 
     // クライアントでも使いたい値（例：S3表示URLなど）は public に書く
     public: {

--- a/front/server/api/generate.post.ts
+++ b/front/server/api/generate.post.ts
@@ -1,0 +1,51 @@
+import { defineEventHandler, readBody } from "h3";
+import { useRuntimeConfig } from "#imports";
+import type { GenerateRequest, GenerateResponse } from "~/types/api";
+
+export default defineEventHandler(
+  async (event): Promise<GenerateResponse | { error: string }> => {
+    const config = useRuntimeConfig();
+    const body = await readBody<GenerateRequest>(event);
+
+    if (!body?.prompt) {
+      return { error: "プロンプトが未入力です。" };
+    }
+
+    const fullPrompt = body.imageUrl
+      ? `以下の画像を参考にして、${body.prompt} → 画像URL: ${body.imageUrl}`
+      : body.prompt;
+
+    const response = await fetch(
+      "https://api.openai.com/v1/images/generations",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${config.openaiApiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "dall-e-3",
+          prompt: fullPrompt,
+          n: 1,
+          size: "1024x1024",
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const error = await response.json();
+      return {
+        error: error?.error?.message || "OpenAI APIの呼び出しに失敗しました。",
+      };
+    }
+
+    const data = await response.json();
+
+    const imageUrl = data?.data?.[0]?.url;
+    if (!imageUrl) {
+      return { error: "画像生成に失敗しました。" };
+    }
+
+    return { imageUrl };
+  }
+);

--- a/front/types/api.ts
+++ b/front/types/api.ts
@@ -1,0 +1,23 @@
+/**
+ * 画像生成リクエスト
+ */
+export interface GenerateRequest {
+  /**
+   * プロンプト
+   */
+  prompt: string;
+  /**
+   * MinIOまたはS3に保存されている画像URL
+   */
+  imageUrl?: string;
+}
+
+/**
+ * 画像生成レスポンス
+ */
+export interface GenerateResponse {
+  /**
+   * 生成された画像URL
+   */
+  imageUrl: string;
+}


### PR DESCRIPTION
## チケット
https://www.notion.so/OpenAI-API-1cd249f41983806f9e81e563fe87c420

## やったこと
・表題の通り
・uploadsバケットのアクセスポリシーをpublicに修正
・APIキー取得
・クレジットカード登録